### PR TITLE
💥 Convert package to ESM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Node CI
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        node: [12.20.0, 14.13.1, 16.0.0]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node }}
+    - name: Install dependencies
+      run: npm install
+    - name: Run tests
+      run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /node_modules/
-/npm-debug.log

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2016-2017 Linus Unnebäck
+Copyright (c) 2016-2021 Linus Unnebäck
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,2 +1,5 @@
-declare function hexToArrayBuffer (hex: string): ArrayBuffer
-export = hexToArrayBuffer
+/**
+ * @param input - specified as a string of hexadecimal characters
+ * @returns a new ArrayBuffer with the binary content from `input`
+ */
+export default function hexToArrayBuffer (input: string): ArrayBuffer

--- a/index.js
+++ b/index.js
@@ -1,16 +1,16 @@
-module.exports = function hexToArrayBuffer (hex) {
-  if (typeof hex !== 'string') {
+export default function hexToArrayBuffer (input) {
+  if (typeof input !== 'string') {
     throw new TypeError('Expected input to be a string')
   }
 
-  if ((hex.length % 2) !== 0) {
+  if ((input.length % 2) !== 0) {
     throw new RangeError('Expected string to be an even number of characters')
   }
 
-  var view = new Uint8Array(hex.length / 2)
+  const view = new Uint8Array(input.length / 2)
 
-  for (var i = 0; i < hex.length; i += 2) {
-    view[i / 2] = parseInt(hex.substring(i, i + 2), 16)
+  for (let i = 0; i < input.length; i += 2) {
+    view[i / 2] = parseInt(input.substring(i, i + 2), 16)
   }
 
   return view.buffer

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "1.1.0",
   "license": "MIT",
   "repository": "LinusU/hex-to-array-buffer",
+  "type": "module",
+  "exports": "./index.js",
   "keywords": [
     "ArrayBuffer",
     "conversion",
@@ -11,10 +13,14 @@
     "string"
   ],
   "scripts": {
-    "test": "standard && node test"
+    "test": "standard && node test && ts-readme-generator --check"
   },
   "devDependencies": {
     "arraybuffer-equal": "^1.0.4",
-    "standard": "^10.0.3"
+    "standard": "^16.0.3",
+    "ts-readme-generator": "^0.5.0"
+  },
+  "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ npm install --save hex-to-array-buffer
 ## Usage
 
 ```js
-const hexToArrayBuffer = require('hex-to-array-buffer')
+import hexToArrayBuffer from 'hex-to-array-buffer'
 
 const buffer = hexToArrayBuffer('ceae96a325e1dc5dd4f405d905049ceb')
 
@@ -21,7 +21,7 @@ console.log(buffer)
 
 ## API
 
-### hexToArrayBuffer(hex: string) => ArrayBuffer
+### `hexToArrayBuffer(input)`
 
-Returns a new ArrayBuffer with the binary content specified as a string of
-hexadecimal characters.
+- `input` (`string`, required) - specified as a string of hexadecimal characters
+- returns `ArrayBuffer` - a new ArrayBuffer with the binary content from `input`

--- a/test.js
+++ b/test.js
@@ -1,11 +1,11 @@
-var assert = require('assert')
-var hexToArrayBuffer = require('./')
-var isEqual = require('arraybuffer-equal')
+import assert from 'node:assert'
+import isEqual from 'arraybuffer-equal'
+import hexToArrayBuffer from './index.js'
 
 function numbersToArrayBuffer (numbers) {
-  var view = new Uint8Array(numbers.length)
+  const view = new Uint8Array(numbers.length)
 
-  for (var i = 0; i < view.length; i++) {
+  for (let i = 0; i < view.length; i++) {
     view[i] = numbers[i]
   }
 


### PR DESCRIPTION
Migration Guide:

This relases changes the package from a Common JS module to an EcmaScript module, and drops support for older versions of Node.

- The minimum version of Node.js supported is now: `12.20.0`, `14.13.1`, and `16.0.0`
- The package must now be imported using the native `import` syntax instead of with `require`